### PR TITLE
Webstorm support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,7 +219,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: pluginVerifier-result
+          name: pluginVerifier-result-${{ matrix.platformType }}
           path: ${{ github.workspace }}/build/reports/pluginVerifier
 
   # Prepare a draft release for GitHub Releases page for the manual verification

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,9 @@ jobs:
     name: Verify plugin
     needs: [ build ]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platformType: ['IU', 'WS']
     steps:
 
       # Free GitHub Actions Environment Disk Space
@@ -209,7 +212,7 @@ jobs:
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
-        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew verifyPlugin -PplatformType=${{ matrix.platformType }} -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ platformVersion = 2023.3.2
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins =
+platformBundledPlugins = JavaScript
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.10.2

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,11 +4,10 @@
     <name>Oxc</name>
     <vendor>iwanabethatguy</vendor>
 
-    <depends>com.intellij.modules.ultimate</depends>
-
+    <depends>com.intellij.modules.platform</depends>
+    <depends>JavaScript</depends>
 
     <resource-bundle>messages.MyBundle</resource-bundle>
-
 
     <applicationListeners>
         <listener class="com.github.iwanabethatguy.oxcintellijplugin.listeners.MyApplicationActivationListener" topic="com.intellij.openapi.application.ApplicationActivationListener"/>


### PR DESCRIPTION
- Change the plugin dependencies to use the base platform (available in all IDEs) and the JavaScript module which is available for Webstorm or any IDE with the JavaScript plugin installed.
- Update to run plugin verification for Webstorm and IntelliJ Ultimate

https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html#declaring-incompatibility-with-module

Depends on #50.