### PR TITLE
Search project contents for oxc_language_server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,7 +219,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: pluginVerifier-result
+          name: pluginVerifier-result-${{ matrix.platformType }}
           path: ${{ github.workspace }}/build/reports/pluginVerifier
 
   # Prepare a draft release for GitHub Releases page for the manual verification

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,9 @@ jobs:
     name: Verify plugin
     needs: [ build ]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platformType: ['IU', 'WS']
     steps:
 
       # Free GitHub Actions Environment Disk Space
@@ -209,7 +212,7 @@ jobs:
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
-        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew verifyPlugin -PplatformType=${{ matrix.platformType }} -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ platformVersion = 2023.3.2
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins =
+platformBundledPlugins = JavaScript
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.10.2

--- a/src/main/kotlin/com/github/iwanabethatguy/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
+++ b/src/main/kotlin/com/github/iwanabethatguy/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
@@ -1,37 +1,59 @@
 package com.github.iwanabethatguy.oxcintellijplugin.lsp
 
-import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
-import com.intellij.openapi.fileTypes.FileType
-import com.intellij.platform.lsp.api.customization.LspDiagnosticsSupport
-import com.intellij.platform.lsp.api.requests.LspRequest
-import org.eclipse.lsp4j.ConfigurationItem
-import org.eclipse.lsp4j.InitializeParams
+import com.intellij.util.FileSearchUtil
+import java.time.Duration
 
+@Suppress("UnstableApiUsage")
 class OxcLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor(project, "Oxc") {
 
-    override fun isSupportedFile(file: VirtualFile):  Boolean {
-        thisLogger().warn("file.extension " + file.extension.toString())
-        return file.extension == "js" ||  file.extension == "jsx" || file.extension == "ts" || file.extension == "tsx"
+    companion object {
+
+        fun supportedFile(file: VirtualFile): Boolean {
+            return file.isInLocalFileSystem && listOf("js", "jsx", "ts", "tsx").contains(
+                file.extension)
+        }
+    }
+
+    override fun isSupportedFile(file: VirtualFile): Boolean {
+        thisLogger().warn(
+            "file.isInLocalFileSystem ${file.isInLocalFileSystem}, file.extension ${file.extension}")
+        return supportedFile(file)
     }
 
     override fun createCommandLine(): GeneralCommandLine {
         thisLogger().warn("Start oxc language server")
 
-        return GeneralCommandLine("oxc_language_server").apply {
-        }
+        return GeneralCommandLine(findBinary())
     }
 
     override fun createInitializationOptions(): Any? {
         val options = super.createInitializationOptions()
-        thisLogger().warn("get oxc configuration" + options.toString())
+        thisLogger().warn("get oxc configuration $options")
         return options
     }
 
+    private fun findBinary(): String {
+        val foundBinaries = roots.map {
+            val fileQuery = FileSearchUtil.findFileRecursively(it, "oxc_language_server", 10,
+                Duration.ofSeconds(5).toMillis())
+            return@map fileQuery.findFirst()
+        }.filterNotNull()
+        if (foundBinaries.size == 1) {
+            return foundBinaries.single().path
+        }
+        if (foundBinaries.size > 1) {
+            thisLogger().warn("Found multiple binaries")
+            return foundBinaries.single().path
+        }
+
+        thisLogger().warn("Unable to find binaries, falling back to PATH")
+        return "oxc_language_server"
+    }
 
     override val lspGoToDefinitionSupport = false
 
@@ -40,6 +62,5 @@ class OxcLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor(
     override val lspFormattingSupport = null
 
     override val lspHoverSupport = false
-
 
 }

--- a/src/main/kotlin/com/github/iwanabethatguy/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/iwanabethatguy/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
@@ -1,16 +1,18 @@
 package com.github.iwanabethatguy.oxcintellijplugin.lsp
+
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.LspServerSupportProvider
-class OxcLspServerSupportProvider: LspServerSupportProvider {
-    override fun fileOpened(project: Project, file: VirtualFile, serverStarter: LspServerSupportProvider.LspServerStarter) {
-        if (!(file.extension == "js" ||  file.extension == "jsx" || file.extension == "ts" || file.extension == "tsx")) return
 
+@Suppress("UnstableApiUsage")
+class OxcLspServerSupportProvider : LspServerSupportProvider {
+
+    override fun fileOpened(project: Project, file: VirtualFile,
+        serverStarter: LspServerSupportProvider.LspServerStarter) {
+        if (!OxcLspServerDescriptor.supportedFile(file)) {
+            return
+        }
 
         serverStarter.ensureServerStarted(OxcLspServerDescriptor(project))
     }
 }
-
-
-
-

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,11 +4,10 @@
     <name>Oxc</name>
     <vendor>iwanabethatguy</vendor>
 
-    <depends>com.intellij.modules.ultimate</depends>
-
+    <depends>com.intellij.modules.platform</depends>
+    <depends>JavaScript</depends>
 
     <resource-bundle>messages.MyBundle</resource-bundle>
-
 
     <applicationListeners>
         <listener class="com.github.iwanabethatguy.oxcintellijplugin.listeners.MyApplicationActivationListener" topic="com.intellij.openapi.application.ApplicationActivationListener"/>


### PR DESCRIPTION
Instead of only launching the server if it's available on your PATH, it will now search your project (for example, if. you have `oxlint` installed from NPM then the language server will be available as well).

This is similar to how the VS Code extension finds the executable.  In a future PR, I'll add a configuration option for a path to the executable.
VS Code extension lookup for reference, https://github.com/oxc-project/oxc/blob/main/editors/vscode/client/extension.ts#L95-L131.

Requires #50 and #51. (Sorry about the stacked PRs, I'm not really sure of a better way to do this.)