### PR TITLE
fix: Only use webstorm as the target platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,9 +176,6 @@ jobs:
     name: Verify plugin
     needs: [ build ]
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platformType: ['IU', 'WS']
     steps:
 
       # Free GitHub Actions Environment Disk Space
@@ -212,14 +209,14 @@ jobs:
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
-        run: ./gradlew verifyPlugin -PplatformType=${{ matrix.platformType }} -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: pluginVerifier-result-${{ matrix.platformType }}
+          name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
 
   # Prepare a draft release for GitHub Releases page for the manual verification

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ pluginSinceBuild = 233
 pluginUntilBuild = 242.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-platformType = IU
+platformType = WS
 platformVersion = 2023.3.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION
If the plugin works with webstorm, it should work with all other IDEs that have the JavaScript plugin installed.  This will reduce the amount of files used during CI and should also reduce overall CI time.