### PR TITLE
feat: Custom language server path

### DIFF
--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/settings/OxcSettingsComponent.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/settings/OxcSettingsComponent.kt
@@ -13,10 +13,19 @@ import com.intellij.openapi.project.Project
 class OxcSettingsComponent(private val project: Project) :
     SimplePersistentStateComponent<OxcSettingsState>(OxcSettingsState()) {
 
+    var binaryPath
+        get() = state.binaryPath
+        set(value) {
+            if (value.isNullOrBlank()) {
+                state.binaryPath = null
+                return
+            }
+            state.binaryPath = value
+        }
+
     var enable
         get() = state.enable
         set(value) {
             state.enable = value
         }
-
 }

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/settings/OxcSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/settings/OxcSettingsConfigurable.kt
@@ -3,12 +3,18 @@ package com.github.oxc.project.oxcintellijplugin.settings
 import com.github.oxc.project.oxcintellijplugin.MyBundle
 import com.github.oxc.project.oxcintellijplugin.lsp.OxcLspServerSupportProvider
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PathMacroManager
 import com.intellij.openapi.components.service
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.BoundSearchableConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.platform.lsp.api.LspServerManager
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
 
 class OxcSettingsConfigurable(private val project: Project) :
@@ -20,17 +26,47 @@ class OxcSettingsConfigurable(private val project: Project) :
 
         return panel {
             row {
-                checkBox("Enabled").bindSelected(settings::enable)
+                checkBox(MyBundle.message("oxc.settings.enabled")).bindSelected(settings::enable)
+            }
+            row(MyBundle.message("oxc.settings.languageServerPath")) {
+                val textField = TextFieldWithBrowseButton()
+                cell(textField).align(AlignX.FILL).applyToComponent {
+                    val fileChooser = FileChooserDescriptorFactory.createSingleFileNoJarsDescriptor()
+                    addBrowseFolderListener(null,
+                        MyBundle.message("oxc.settings.selectPathToLanguageServer"), null,
+                        fileChooser)
+                }.bindText({
+                    return@bindText expandToSystemDependentPath(settings.binaryPath)
+                }, {
+                    settings.binaryPath = collapseToSystemIndependentPath(it)
+                })
             }
         }
     }
 
     override fun apply() {
         super.apply()
-        @Suppress("UnstableApiUsage")
-        ApplicationManager.getApplication().invokeLater {
+        @Suppress("UnstableApiUsage") ApplicationManager.getApplication().invokeLater {
             project.service<LspServerManager>()
                 .stopAndRestartIfNeeded(OxcLspServerSupportProvider::class.java)
         }
+    }
+
+    private fun collapseToSystemIndependentPath(path: String?): String {
+        if (path.isNullOrBlank()) {
+            return ""
+        }
+
+        val pathMacroManager = project.service<PathMacroManager>()
+        return FileUtil.toSystemIndependentName(pathMacroManager.collapsePath(path))
+    }
+
+    private fun expandToSystemDependentPath(path: String?): String {
+        if (path.isNullOrBlank()) {
+            return ""
+        }
+
+        val pathMacroManager = project.service<PathMacroManager>()
+        return FileUtil.toSystemDependentName(pathMacroManager.expandPath(path))
     }
 }

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/settings/OxcSettingsState.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/settings/OxcSettingsState.kt
@@ -5,6 +5,9 @@ import com.intellij.util.xml.Attribute
 
 class OxcSettingsState : BaseState() {
 
+    @get:Attribute("binaryPath")
+    var binaryPath by string()
+
     @get:Attribute("enable")
     var enable by property(true)
 }

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -2,3 +2,6 @@ action.com.github.oxc.project.oxcintellijplugin.actions.RestartLanguageServer.te
 
 oxc.name=Oxc
 oxc.schema.name=Oxc
+oxc.settings.enabled=Enabled
+oxc.settings.languageServerPath=Oxc Language Server Path
+oxc.settings.selectPathToLanguageServer=Select path to Oxc language server


### PR DESCRIPTION
I don't have a Windows device to test this on, but the concern is whether the paths should be normalized and then collapsed/expanded or collapsed/expanded and then normalized.

`FileUtil#toSystemDependentName`, `FileUtil#toSystemIndependentName`, `PathMacroManager#expandPath`, and `PathMacroManager#collapsePath` are the relevant methods we are using for that normalizing process.

This PR is built on top of #79.  Once that is merged in this can be rebased to see the smaller diff. (79 only contains changelog updates though, so it really isnt much different here.)

Closes #64.