### PR TITLE
feat: Add eslint config file support

### DIFF
--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/Constants.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/Constants.kt
@@ -2,6 +2,7 @@ package com.github.oxc.project.oxcintellijplugin
 
 object Constants {
 
-    val CONFIG_FILES = listOf("oxlintrc.json", "oxlint.json", ".oxlintrc.json", ".oxlint.json",
-        ".oxlintrc")
+    val ESLINT_CONFIG_FILES = listOf(".eslintrc", ".eslintrc.json")
+    val OXLINT_CONFIG_FILES = listOf("oxlintrc.json", "oxlint.json", ".oxlintrc.json",
+        ".oxlint.json", ".oxlintrc")
 }

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/OxcIconProvider.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/OxcIconProvider.kt
@@ -16,7 +16,7 @@ class OxcIconProvider : IconProvider(), DumbAware {
         if (!file.isValid || file.isDirectory) {
             return null
         }
-        if (Constants.CONFIG_FILES.contains(file.name)) {
+        if (Constants.OXLINT_CONFIG_FILES.contains(file.name)) {
             return OxcIcons.OxcRound
         }
 

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/OxcSchemaProviderFactory.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/OxcSchemaProviderFactory.kt
@@ -13,7 +13,7 @@ class OxcSchemaProviderFactory : JsonSchemaProviderFactory {
     override fun getProviders(project: Project): List<JsonSchemaFileProvider?> {
         return listOf(object : JsonSchemaFileProvider {
             override fun isAvailable(file: VirtualFile): Boolean {
-                return Constants.CONFIG_FILES.contains(file.name)
+                return Constants.OXLINT_CONFIG_FILES.contains(file.name)
             }
 
             override fun getName(): @Nls String {

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxlintConfigWatcher.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxlintConfigWatcher.kt
@@ -14,7 +14,8 @@ class OxlintConfigWatcher : BulkFileListener {
         val configChanged = events.any { event ->
             val fileName = event.path.substringAfterLast("/")
 
-            return@any Constants.CONFIG_FILES.contains(fileName)
+            return@any (Constants.OXLINT_CONFIG_FILES + Constants.ESLINT_CONFIG_FILES).contains(
+                fileName)
         }
 
         if (configChanged) {


### PR DESCRIPTION
Use Oxlint config files for icons and JSON schemas.
Use Eslint and Oxlint config files for triggering language server restarts when the config file changes.

If a user has the Oxc plugin but not the Eslint plugin, then they will likely have a lesser experience if they try to use an Eslint file.  I think this is reasonable, but we could also come up with something more complicated if desired.  For example, check if the Eslint plugin is enabled and if not we could treat an Eslint config file the same as an Oxlint config file (Oxlint icon, Oxlint JSON schema).