### PR TITLE
fix: Update supported file extensions

### DIFF
--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
@@ -16,10 +16,14 @@ import org.eclipse.lsp4j.InitializeParams
 class OxcLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor(project, "Oxc") {
 
     companion object {
-
         fun supportedFile(file: VirtualFile): Boolean {
-            return file.isInLocalFileSystem && listOf("js", "jsx", "ts", "tsx").contains(
-                file.extension)
+            return file.isInLocalFileSystem && listOf(
+                "astro",
+                "js", "jsx", "cjs", "mjs",
+                "svelte",
+                "ts", "tsx", "cts", "mts",
+                "vue"
+            ).contains(file.extension)
         }
     }
 


### PR DESCRIPTION
Synced up with the file extensions mentioned https://oxc.rs/docs/guide/usage/linter.html.  Not sure if there is a better source for this info.

FYI @Smrtnyk I believe this should resolve your issue with Vue files.