### PR TITLE
fix: Update renovate to modify gradle.properties when updating the gradle wrapper version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,10 @@
       "matchManagers": ["gradle"],
       "rangeStrategy": "auto"
     }
-  ]
+  ],
+  "gradle-wrapper": {
+    "fileMatch": [
+      "(^|/)gradle\\.properties$"
+    ]
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ platformPlugins =
 platformBundledPlugins = JavaScript
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.10.2
+gradleVersion = 8.13
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
I think this should work, but I don't know how to test it. What I'm not sure of is how Renovate knows to update the `gradleVersion` property within the newly configured file.