### PR TITLE
chore: Update run verifications run configuration to not use a before run task

### DIFF
--- a/.run/Run Verifications.run.xml
+++ b/.run/Run Verifications.run.xml
@@ -11,6 +11,7 @@
       </option>
       <option name="taskNames">
         <list>
+          <option value="clean" />
           <option value="verifyPlugin" />
         </list>
       </option>
@@ -19,8 +20,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
-    <method v="2">
-      <option name="Gradle.BeforeRunTask" enabled="true" tasks="clean" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="" />
-    </method>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
   </configuration>
 </component>


### PR DESCRIPTION
This controls the run configurations available within JetBrains products. Typically used as a UI alternative to command line options.

Development only change.