### PR TITLE
fix: Diagnostic may not always have a code so fallback to a default message in these cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix diagnostic may not have a code causing a NullPointerException to be thrown.
+
 ## [0.0.2] - 2025-04-15
 
 ### Fixed

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspDiagnosticsSupport.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspDiagnosticsSupport.kt
@@ -1,5 +1,6 @@
 package com.github.oxc.project.oxcintellijplugin.lsp
 
+import com.github.oxc.project.oxcintellijplugin.OxcBundle
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.platform.lsp.api.customization.LspDiagnosticsSupport
 import org.eclipse.lsp4j.Diagnostic
@@ -9,14 +10,16 @@ class OxcLspDiagnosticsSupport : LspDiagnosticsSupport() {
 
     override fun getMessage(diagnostic: Diagnostic): String {
         thisLogger().debug("Creating message for diagnostic: $diagnostic")
-        return "${diagnostic.source}: ${diagnostic.message} ${diagnostic.code.get()}"
+        return "${diagnostic.source}: ${diagnostic.message} ${
+            diagnostic.code?.get() ?: OxcBundle.message("oxc.diagnostic.unknown.code")
+        }"
     }
 
     override fun getTooltip(diagnostic: Diagnostic): String {
         thisLogger().debug("Creating tooltip for diagnostic: $diagnostic")
-        var rule = diagnostic.code.get()
+        var rule = diagnostic.code.get() ?: OxcBundle.message("oxc.diagnostic.unknown.code")
         if (diagnostic.codeDescription?.href != null) {
-            rule = "<a href=\"${diagnostic.codeDescription.href}\">${diagnostic.code.get()}</a>"
+            rule = "<a href=\"${diagnostic.codeDescription.href}\">${rule}</a>"
         }
 
         return "${diagnostic.source}: ${diagnostic.message} $rule"

--- a/src/main/resources/messages/OxcBundle.properties
+++ b/src/main/resources/messages/OxcBundle.properties
@@ -25,3 +25,4 @@ oxc.settings.oxlintRunTrigger=Oxlint Execution Trigger
 oxc.settings.selectPathToLanguageServer=Select Path to Oxc Language Server
 oxc.supported.extensions.comment=Enter file extensions separated by commas (e.g., .js, .ts, .jsx). Each extension must start with '.' and contain only alphanumeric characters.
 oxc.supported.extensions.label=Supported File Extensions:
+oxc.diagnostic.unknown.code=Unknown Code


### PR DESCRIPTION
Fix #152.

I haven't been able to find a test case for this, but the fix seems pretty simple. `diagnostic.code` is nullable, so just handle that scenario.