### PR TITLE
feat!: Migrate to new Oxc language server format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Add run trigger to config settings. Allow triggering Oxlint either on save or on type.
 
+### Changed
+
+- Use the new Oxc Language Server config format. This requires Oxlint 0.16.11 or newer.
+
 ## [0.0.8] - 2025-05-19
 
 ### Added


### PR DESCRIPTION
BREAKING CHANGE: Oxlint 0.16.11 or newer is required for this new format

Fixes https://github.com/oxc-project/oxc-intellij-plugin/issues/185.
Fixes https://github.com/oxc-project/oxc-intellij-plugin/issues/192.