### PR TITLE
build: Remove anchor to pass IntelliJ plugin description validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- Plugin description -->
 
-# ⚓ Oxc
+# Oxc
 
 The Oxidation Compiler is creating a suite of high-performance tools for JavaScript and TypeScript.
 


### PR DESCRIPTION
Plugin descriptions must start with a latin character