### PR TITLE
fix: Ignore plugin verifier problems

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,6 +112,7 @@ intellijPlatform {
         ides {
             recommended()
         }
+        ignoredProblemsFile.set(File("plugin-verifier-ignored-problems.txt"))
     }
 }
 

--- a/plugin-verifier-ignored-problems.txt
+++ b/plugin-verifier-ignored-problems.txt
@@ -1,0 +1,2 @@
+Access to unresolved class com.intellij.javascript.nodejs.util.NodePackage.Companion.*
+Access to unresolved field com.intellij.javascript.nodejs.util.NodePackage.Companion.*


### PR DESCRIPTION
Some plugin compatibility issues are being reported that don't seem to be accurate, so this prevents those from failing the build