### PR TITLE
feat: remove pluginUntilBuild to always support latest IDE versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ pluginVersion = 0.0.11
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243
-pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = WS


### PR DESCRIPTION
Remove pluginUntilBuild to ensure the plugin is always installable on the latest IDE versions, including EAP builds — such as Biome: https://github.com/biomejs/biome-intellij/blob/main/gradle.properties via commit https://github.com/biomejs/biome-intellij/commit/59e9b3349c65113a5298686f54376843fc5764d0.