### PR TITLE
chore(deps): Update kotlin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ junit = "4.13.2"
 # plugins
 changelog = "2.2.1"
 intelliJPlatform = "2.6.0"
-kotlin = "2.1.21"
+kotlin = "2.2.0"
 kover = "0.9.1"
 qodana = "2025.1.1"
 

--- a/plugin-verifier-ignored-problems.txt
+++ b/plugin-verifier-ignored-problems.txt
@@ -1,2 +1,3 @@
 Access to unresolved class com.intellij.javascript.nodejs.util.NodePackage.Companion.*
 Access to unresolved field com.intellij.javascript.nodejs.util.NodePackage.Companion.*
+Access to unresolved class kotlin.coroutines.jvm.internal.SpillingKt


### PR DESCRIPTION
Ignore incompatibility with 2024.3 IntelliJ version as it still seems to work fine