### PR TITLE
fix: Always use the location of package.json with oxlint installed as the project root

### DIFF
--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
@@ -1,5 +1,6 @@
 package com.github.oxc.project.oxcintellijplugin.lsp
 
+import com.github.oxc.project.oxcintellijplugin.OxcPackage
 import com.github.oxc.project.oxcintellijplugin.OxcTargetRun
 import com.github.oxc.project.oxcintellijplugin.OxcTargetRunBuilder
 import com.github.oxc.project.oxcintellijplugin.settings.OxcSettings
@@ -91,10 +92,11 @@ class OxcLspServerDescriptor(
     override val lspDiagnosticsSupport: LspDiagnosticsSupport? = OxcLspDiagnosticsSupport()
 
     private fun createWorkspaceConfig(workspace: VirtualFile): Map<String, Any?> {
+        val oxcPackage = OxcPackage(project)
         val settings = OxcSettings.getInstance(project)
 
         return mapOf(
-            "configPath" to settings.state.configPath,
+            "configPath" to oxcPackage.configPath(),
             "flags" to emptyMap<String, String>(),
             "run" to settings.state.runTrigger.toLspValue()
         )

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
@@ -2,18 +2,15 @@ package com.github.oxc.project.oxcintellijplugin.lsp
 
 import com.github.oxc.project.oxcintellijplugin.OxcIcons
 import com.github.oxc.project.oxcintellijplugin.OxcPackage
-import com.github.oxc.project.oxcintellijplugin.extensions.findNearestOxcConfig
-import com.github.oxc.project.oxcintellijplugin.extensions.findNearestPackageJson
 import com.github.oxc.project.oxcintellijplugin.settings.OxcConfigurable
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.platform.lsp.api.LspServer
 import com.intellij.platform.lsp.api.LspServerSupportProvider
 import com.intellij.platform.lsp.api.lsWidget.LspServerWidgetItem
-import java.io.File
+import kotlin.io.path.Path
 
 @Suppress("UnstableApiUsage")
 class OxcLspServerSupportProvider : LspServerSupportProvider {
@@ -26,17 +23,9 @@ class OxcLspServerSupportProvider : LspServerSupportProvider {
         if (!oxc.isEnabled()) {
             return
         }
-        val configPath = oxc.configPath()
         val executable = oxc.binaryPath(file) ?: return
-
-        val projectRootDir = project.guessProjectDir() ?: return
-        val root: VirtualFile
-        if (configPath?.isNotEmpty() == true) {
-            val configVirtualFile = VirtualFileManager.getInstance().findFileByNioPath(File(configPath).toPath()) ?: return
-            root = configVirtualFile.findNearestPackageJson(projectRootDir)?.parent ?: return
-        } else {
-            root = file.findNearestOxcConfig(projectRootDir)?.parent ?: projectRootDir
-        }
+        val nodePackage = oxc.getPackage(file) ?: return
+        val root = VirtualFileManager.getInstance().findFileByNioPath(Path(nodePackage.systemIndependentPath))?.parent?.parent ?: return
 
         serverStarter.ensureServerStarted(OxcLspServerDescriptor(project, root, executable))
     }


### PR DESCRIPTION
Fixes #234.