### PR TITLE
fix: Modify language server lifecycle

### DIFF
--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/listeners/EditorWatcher.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/listeners/EditorWatcher.kt
@@ -1,0 +1,26 @@
+package com.github.oxc.project.oxcintellijplugin.listeners
+
+import com.github.oxc.project.oxcintellijplugin.services.OxcServerService
+import com.github.oxc.project.oxcintellijplugin.settings.OxcSettings
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.vfs.VirtualFile
+
+class EditorWatcher : FileEditorManagerListener {
+
+    override fun fileClosed(source: FileEditorManager, file: VirtualFile) {
+        val project = source.project
+        if (source.allEditors.isEmpty()) {
+            OxcServerService.getInstance(project).stopServer()
+            return
+        }
+
+        val stillHasSupportedFileOpen = source.allEditors.any {
+            OxcSettings.getInstance(project).fileSupported(it.file)
+        }
+        if (!stillHasSupportedFileOpen) {
+            OxcServerService.getInstance(project).stopServer()
+        }
+    }
+
+}

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
@@ -3,6 +3,7 @@ package com.github.oxc.project.oxcintellijplugin.lsp
 import com.github.oxc.project.oxcintellijplugin.OxcIcons
 import com.github.oxc.project.oxcintellijplugin.OxcPackage
 import com.github.oxc.project.oxcintellijplugin.settings.OxcConfigurable
+import com.github.oxc.project.oxcintellijplugin.settings.OxcSettings
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -18,6 +19,10 @@ class OxcLspServerSupportProvider : LspServerSupportProvider {
         file: VirtualFile,
         serverStarter: LspServerSupportProvider.LspServerStarter) {
         thisLogger().debug("Handling fileOpened for ${file.path}")
+
+        if (!OxcSettings.getInstance(project).fileSupported(file)) {
+            return
+        }
 
         val oxc = OxcPackage(project)
         if (!oxc.isEnabled()) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -58,4 +58,9 @@
                 topic="com.intellij.openapi.vfs.newvfs.BulkFileListener"
         />
     </applicationListeners>
+
+    <projectListeners>
+        <listener class="com.github.oxc.project.oxcintellijplugin.listeners.EditorWatcher"
+                topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
+    </projectListeners>
 </idea-plugin>


### PR DESCRIPTION
Shutdown the language server when the last relevant file is closed
Only start the language server when a relevant file is opened

Fixes #239.