### PR TITLE
fix: Update minimum IDE version to fix compatibility with most recent Kotlin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Resolve language server not stopping when closing all relevant files.
 - Resolve language server starting when opening irrelevant files.
 
+### Removed
+
+- Removed support for IDE versions 2024.3.
+
 ## [0.0.12] - 2025-06-24
 
 ### Added 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ pluginRepositoryUrl = https://github.com/oxc-project/oxc-intellij-plugin
 pluginVersion = 0.0.13
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 243
+pluginSinceBuild = 251
 pluginUntilBuild = 252.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = WS
-platformVersion = 2024.3.6
+platformVersion = 2025.1.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/plugin-verifier-ignored-problems.txt
+++ b/plugin-verifier-ignored-problems.txt
@@ -1,3 +1,0 @@
-Access to unresolved class com.intellij.javascript.nodejs.util.NodePackage.Companion.*
-Access to unresolved field com.intellij.javascript.nodejs.util.NodePackage.Companion.*
-Access to unresolved class kotlin.coroutines.jvm.internal.SpillingKt

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspDiagnosticsSupport.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspDiagnosticsSupport.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.platform.lsp.api.customization.LspDiagnosticsSupport
 import org.eclipse.lsp4j.Diagnostic
 
-@Suppress("UnstableApiUsage")
 class OxcLspDiagnosticsSupport : LspDiagnosticsSupport() {
 
     override fun getMessage(diagnostic: Diagnostic): String {

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
@@ -15,7 +15,6 @@ import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.ConfigurationItem
 import org.eclipse.lsp4j.InitializeParams
 
-@Suppress("UnstableApiUsage")
 class OxcLspServerDescriptor(
     project: Project,
     root: VirtualFile,
@@ -89,7 +88,7 @@ class OxcLspServerDescriptor(
 
     override val lspHoverSupport = false
 
-    override val lspDiagnosticsSupport: LspDiagnosticsSupport? = OxcLspDiagnosticsSupport()
+    override val lspDiagnosticsSupport: LspDiagnosticsSupport = OxcLspDiagnosticsSupport()
 
     private fun createWorkspaceConfig(workspace: VirtualFile): Map<String, Any?> {
         val oxcPackage = OxcPackage(project)

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
@@ -13,7 +13,6 @@ import com.intellij.platform.lsp.api.LspServerSupportProvider
 import com.intellij.platform.lsp.api.lsWidget.LspServerWidgetItem
 import kotlin.io.path.Path
 
-@Suppress("UnstableApiUsage")
 class OxcLspServerSupportProvider : LspServerSupportProvider {
     override fun fileOpened(project: Project,
         file: VirtualFile,
@@ -36,7 +35,7 @@ class OxcLspServerSupportProvider : LspServerSupportProvider {
     }
 
     override fun createLspServerWidgetItem(lspServer: LspServer,
-        currentFile: VirtualFile?): LspServerWidgetItem? {
+        currentFile: VirtualFile?): LspServerWidgetItem {
         return LspServerWidgetItem(lspServer, currentFile, OxcIcons.OxcRound, OxcConfigurable::class.java)
     }
 }

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/services/OxcServerService.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/services/OxcServerService.kt
@@ -1,5 +1,3 @@
-@file:Suppress("UnstableApiUsage")
-
 package com.github.oxc.project.oxcintellijplugin.services
 
 import com.github.oxc.project.oxcintellijplugin.OxcBundle
@@ -34,7 +32,7 @@ class OxcServerService(private val project: Project) {
     suspend fun fixAll(document: Document) {
         val manager = FileDocumentManager.getInstance()
         val file = manager.getFile(document) ?: return
-        
+
         fixAll(file, document)
     }
 

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/settings/OxcConfigurable.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/settings/OxcConfigurable.kt
@@ -84,12 +84,14 @@ class OxcConfigurable(private val project: Project) :
             // *********************
             panel {
                 row(OxcBundle.message("oxc.settings.languageServerPath")) {
+                    @Suppress("UnstableApiUsage")
                     textFieldWithBrowseButton(OxcBundle.message("oxc.settings.languageServerPath")) {
                         it.path
                     }.align(AlignX.FILL).bindText(settings::binaryPath)
                 }.visibleIf(manualConfiguration.selected)
 
                 row(OxcBundle.message("oxc.config.path.label")) {
+                    @Suppress("UnstableApiUsage")
                     textFieldWithBrowseButton(
                         OxcBundle.message("oxc.config.path.label"),
                         project,
@@ -161,7 +163,7 @@ class OxcConfigurable(private val project: Project) :
 
     override fun apply() {
         super.apply()
-        @Suppress("UnstableApiUsage") ApplicationManager.getApplication().invokeLater {
+        ApplicationManager.getApplication().invokeLater {
             project.service<LspServerManager>().stopAndRestartIfNeeded(OxcLspServerSupportProvider::class.java)
         }
     }


### PR DESCRIPTION
Missing SpillingKt results in an exception when trying to apply Oxc fixes within the editor