### PR TITLE
fix: If oxlint isn't installed in node_modules then use the project root as the working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix working directory lookup when specifying a language server path that is not part of a node_modules installation.
+
 ## [0.0.15] - 2025-08-28
 
 ### Added

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerSupportProvider.kt
@@ -6,6 +6,7 @@ import com.github.oxc.project.oxcintellijplugin.settings.OxcConfigurable
 import com.github.oxc.project.oxcintellijplugin.settings.OxcSettings
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.platform.lsp.api.LspServer
@@ -28,8 +29,12 @@ class OxcLspServerSupportProvider : LspServerSupportProvider {
             return
         }
         val executable = oxc.binaryPath(file) ?: return
-        val nodePackage = oxc.getPackage(file) ?: return
-        val root = VirtualFileManager.getInstance().findFileByNioPath(Path(nodePackage.systemIndependentPath))?.parent?.parent ?: return
+        val nodePackage = oxc.getPackage(file)
+        val root = if (nodePackage != null) {
+            VirtualFileManager.getInstance().findFileByNioPath(Path(nodePackage.systemIndependentPath))?.parent?.parent ?: return
+        } else {
+            ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(file) ?: return
+        }
 
         serverStarter.ensureServerStarted(OxcLspServerDescriptor(project, root, executable))
     }


### PR DESCRIPTION
Fixes #260.

This may not work correctly with multiple workspaces, but those aren't really supported with the plugin right now anyways. Worst case, this fixes some users with a manual binary path. It shouldn't impact anybody with a working existing setup.