### PR TITLE
build: Fix deprecated API usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,15 @@ pluginRepositoryUrl = https://github.com/oxc-project/oxc-intellij-plugin
 pluginVersion = 0.0.17
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 251
+pluginSinceBuild = 252
 # This is unset so that we don't have to publish a new plugin version for every major.minor version of IntelliJ IDE.
 # https://github.com/oxc-project/oxc-intellij-plugin/issues/231
 # pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
+# Use IU as the platformType to download docs/sources for IntelliJ classes in the IDE.
 platformType = WS
-platformVersion = 2025.1.3
+platformVersion = 2025.2.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/lsp/OxcLspServerDescriptor.kt
@@ -10,7 +10,11 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.LspServerDescriptor
-import com.intellij.platform.lsp.api.customization.LspDiagnosticsSupport
+import com.intellij.platform.lsp.api.customization.LspCompletionDisabled
+import com.intellij.platform.lsp.api.customization.LspCustomization
+import com.intellij.platform.lsp.api.customization.LspFormattingDisabled
+import com.intellij.platform.lsp.api.customization.LspGoToDefinitionDisabled
+import com.intellij.platform.lsp.api.customization.LspHoverDisabled
 import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.ConfigurationItem
 import org.eclipse.lsp4j.InitializeParams
@@ -80,15 +84,20 @@ class OxcLspServerDescriptor(
             }
         }
 
-    override val lspGoToDefinitionSupport = false
+    override val lspCustomization: LspCustomization
+        get() {
+            return object : LspCustomization() {
+                override val goToDefinitionCustomizer = LspGoToDefinitionDisabled
 
-    override val lspCompletionSupport = null
+                override val completionCustomizer = LspCompletionDisabled
 
-    override val lspFormattingSupport = null
+                override val formattingCustomizer = LspFormattingDisabled
 
-    override val lspHoverSupport = false
+                override val hoverCustomizer = LspHoverDisabled
 
-    override val lspDiagnosticsSupport: LspDiagnosticsSupport = OxcLspDiagnosticsSupport()
+                override val diagnosticsCustomizer = OxcLspDiagnosticsSupport()
+            }
+        }
 
     private fun createWorkspaceConfig(workspace: VirtualFile): Map<String, Any?> {
         val oxcPackage = OxcPackage(project)


### PR DESCRIPTION
Opening this as a draft. This resolves the issue, but requires us to bump our supported IDE versions. This is just a deprecation, so we can leave it like this until it is actually removed in the new versions.

Updates to new LSP classes. Requires at least IntelliJ 2025.2.3

Fixes #286.