### PR TITLE
build: Stop specifying a pluginUntilBuild version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,9 @@ pluginVersion = 0.0.17
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251
-pluginUntilBuild = 253.*
+# This is unset so that we don't have to publish a new plugin version for every major.minor version of IntelliJ IDE.
+# https://github.com/oxc-project/oxc-intellij-plugin/issues/231
+# pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = WS


### PR DESCRIPTION
This will mark the plugin as compatible with all future versions. Setting the actual compatibility for a plugin version can be modified within the JetBrains marketplace manually as needed.

Fixes #231.