### PR TITLE
Handle WSL paths correctly

### DIFF
--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/OxcTargetRun.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/OxcTargetRun.kt
@@ -74,11 +74,9 @@ class OxcTargetRunBuilder(val project: Project) {
             throw ExecutionException(OxlintBundle.message("oxlint.language.server.not.found"))
         }
 
-        // Detect if it's a WSL path
         val wslPath = WslPath.parseWindowsUncPath(executable)
 
         // For WSL paths, always use NodeProcessCommandBuilder as it handles WSL correctly
-        // Otherwise, check the shebang only for local Windows paths
         val isNodeJs = if (wslPath != null) {
             true
         } else {


### PR DESCRIPTION
I still need to do more testing and may write unit tests, but it looks like it's working now, sadly oxfmt is not yet supported. 

Tested on Windows 11 24H2, WSL 2 with Arch (official image)

<img width="1386" height="993" alt="image" src="https://github.com/user-attachments/assets/6bedf8fe-a23c-4639-8f43-d54f7df7beb1" />
