### PR TITLE
build: Adjust dependencies to work with free IDEs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,8 @@ pluginRepositoryUrl = https://github.com/oxc-project/oxc-intellij-plugin
 pluginVersion = 0.0.21
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 251
+# First version that supports the LSP APIs in free IDEs
+pluginSinceBuild = 252.25557
 # This is unset so that we don't have to publish a new plugin version for every major.minor version of IntelliJ IDE.
 # https://github.com/oxc-project/oxc-intellij-plugin/issues/231
 # pluginUntilBuild =
@@ -20,7 +21,7 @@ platformVersion = 2025.1.3
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins = JavaScript
+platformBundledPlugins =
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
     <vendor email="boshenc@gmail.com" url="https://oxc.rs">Oxc</vendor>
 
     <depends>com.intellij.modules.platform</depends>
-    <depends>JavaScript</depends>
+    <depends>com.intellij.modules.lsp</depends>
 
     <resource-bundle>messages.OxfmtBundle</resource-bundle>
     <resource-bundle>messages.OxlintBundle</resource-bundle>


### PR DESCRIPTION
This doesn't work right now. Removing the JavaScript module requires replacing it with something else. At a glance, it looks like it would be quite a bit of extra maintenance to get this done.