### PR TITLE
fix: Normalize text new lines to \n before updating the Document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalize text newlines when using Oxfmt fixes or format on save.
+
 ## [0.0.21] - 2025-12-09
 
 ### Added

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxfmt/services/OxfmtServerService.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxfmt/services/OxfmtServerService.kt
@@ -57,7 +57,8 @@ class OxfmtServerService(private val project: Project) {
                     val startLineOffset = document.getLineStartOffset(it.range.start.line)
                     val endLineOffset = document.getLineStartOffset(it.range.end.line)
                     document.replaceString(startLineOffset + it.range.start.character,
-                        endLineOffset + it.range.end.character, it.newText)
+                        endLineOffset + it.range.end.character,
+                        it.newText.lines().joinToString(separator = "\n"))
                 }
             })
     }


### PR DESCRIPTION
Fixes #357.