### PR TITLE
fix: resolve nested configs properly

### DIFF
--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/lsp/OxlintLspServerDescriptor.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/lsp/OxlintLspServerDescriptor.kt
@@ -1,8 +1,10 @@
 package com.github.oxc.project.oxcintellijplugin.oxlint.lsp
 
+import com.github.oxc.project.oxcintellijplugin.ConfigurationMode
 import com.github.oxc.project.oxcintellijplugin.OxcTargetRun
 import com.github.oxc.project.oxcintellijplugin.OxcTargetRunBuilder
 import com.github.oxc.project.oxcintellijplugin.ProcessCommandParameter
+import com.github.oxc.project.oxcintellijplugin.extensions.findNearestOxlintConfig
 import com.github.oxc.project.oxcintellijplugin.oxlint.OxlintPackage
 import com.github.oxc.project.oxcintellijplugin.oxlint.settings.OxlintSettings
 import com.intellij.execution.configurations.GeneralCommandLine
@@ -31,9 +33,14 @@ class OxlintLspServerDescriptor(
 
     override fun isSupportedFile(file: VirtualFile): Boolean {
         thisLogger().debug("file.path ${file.path}")
-        return OxlintSettings.getInstance(project).fileSupported(file) && roots.any { root ->
-            file.toNioPath().startsWith(root.toNioPath())
+        if (!OxlintSettings.getInstance(project).fileSupported(file)) return false
+        val configurationMode = OxlintSettings.getInstance(project).configurationMode
+        if (configurationMode != ConfigurationMode.AUTOMATIC) {
+            return roots.any { root -> file.toNioPath().startsWith(root.toNioPath()) }
         }
+        val projectRoot = roots.minByOrNull { it.toNioPath().nameCount } ?: return false
+        val nearestConfigDir = file.findNearestOxlintConfig(root = projectRoot)?.parent ?: projectRoot
+        return roots.any { it == nearestConfigDir }
     }
 
     override fun createCommandLine(): GeneralCommandLine {

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/lsp/OxlintLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/lsp/OxlintLspServerSupportProvider.kt
@@ -1,6 +1,8 @@
 package com.github.oxc.project.oxcintellijplugin.oxlint.lsp
 
+import com.github.oxc.project.oxcintellijplugin.ConfigurationMode
 import com.github.oxc.project.oxcintellijplugin.OxcIcons
+import com.github.oxc.project.oxcintellijplugin.extensions.findNearestOxlintConfig
 import com.github.oxc.project.oxcintellijplugin.oxlint.OxlintPackage
 import com.github.oxc.project.oxcintellijplugin.oxlint.settings.OxlintConfigurable
 import com.github.oxc.project.oxcintellijplugin.oxlint.settings.OxlintSettings
@@ -30,10 +32,17 @@ class OxlintLspServerSupportProvider : LspServerSupportProvider {
         }
         val executable = oxc.binaryPath(file) ?: return
         val nodePackage = oxc.getPackage(file)
-        val root = if (nodePackage != null) {
+        val projectRoot = if (nodePackage != null) {
             VirtualFileManager.getInstance().findFileByNioPath(Path(nodePackage.systemIndependentPath))?.parent?.parent ?: return
         } else {
             ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(file) ?: return
+        }
+
+        val configurationMode = OxlintSettings.getInstance(project).configurationMode
+        val root = if (configurationMode == ConfigurationMode.AUTOMATIC) {
+            file.findNearestOxlintConfig(root = projectRoot)?.parent ?: projectRoot
+        } else {
+            projectRoot
         }
 
         serverStarter.ensureServerStarted(OxlintLspServerDescriptor(project, root, executable, oxc.binaryParameters(file)))


### PR DESCRIPTION
Fixes #404 

1. When a new file is opened, use nearest config as LSP server root (rather than always using project root)
2. If an existing server is running, determine `isSupportedFile` by checking if the _nearest_ config is that server. This prevents root from "claiming" all files

Questions:
- do we need a test for this?
- should we move this so it can be shared with oxfmt? 