### PR TITLE
fix: Nested oxlint configs always disabled due to deprecated flags format

### DIFF
--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/extensions/FileExt.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/extensions/FileExt.kt
@@ -24,8 +24,11 @@ private fun VirtualFile.findNearestFile(
     return null
 }
 
-fun VirtualFile.isOxlintConfigFile(): Boolean =
+fun VirtualFile.isOxlintJsonConfigFile(): Boolean =
     OxlintPackage.configValidExtensions.map { "${OxlintPackage.CONFIG_NAME}.$it" }.contains(this.name)
+
+fun VirtualFile.isOxlintConfigFile(): Boolean =
+    isOxlintJsonConfigFile() || this.name == OxlintPackage.CONFIG_TS_NAME
 
 fun VirtualFile.isOxfmtConfigFile(): Boolean =
     OxfmtPackage.CONFIG_VALID_EXTENSIONS.map { "${OxfmtPackage.CONFIG_NAME}.$it" }.contains(this.name)

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/OxlintPackage.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/OxlintPackage.kt
@@ -114,7 +114,8 @@ class OxlintPackage(private val project: Project) {
 
     companion object {
         const val CONFIG_NAME = ".oxlintrc"
+        const val CONFIG_TS_NAME = "oxlint.config.ts"
         val OXLINT_FIRST_LSP_VERSION = SemVer("1.29.0", 1, 29, 0)
-        val configValidExtensions = listOf("json")
+        val configValidExtensions = listOf("json", "jsonc")
     }
 }

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/OxlintSchemaProviderFactory.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/OxlintSchemaProviderFactory.kt
@@ -1,6 +1,6 @@
 package com.github.oxc.project.oxcintellijplugin.oxlint
 
-import com.github.oxc.project.oxcintellijplugin.extensions.isOxlintConfigFile
+import com.github.oxc.project.oxcintellijplugin.extensions.isOxlintJsonConfigFile
 import com.github.oxc.project.oxcintellijplugin.oxlint.settings.OxlintSettings
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -16,7 +16,7 @@ class OxlintSchemaProviderFactory : JsonSchemaProviderFactory {
         return listOf(object : JsonSchemaFileProvider {
             override fun isAvailable(file: VirtualFile): Boolean {
                 val settings = OxlintSettings.getInstance(project)
-                return settings.state.configPath == file.path || file.isOxlintConfigFile()
+                return settings.state.configPath == file.path || file.isOxlintJsonConfigFile()
             }
 
             override fun getName(): @Nls String {

--- a/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/lsp/OxlintLspServerDescriptor.kt
+++ b/src/main/kotlin/com/github/oxc/project/oxcintellijplugin/oxlint/lsp/OxlintLspServerDescriptor.kt
@@ -99,6 +99,9 @@ class OxlintLspServerDescriptor(
 
         return mapOf(
             "configPath" to oxlintPackage.configPath(),
+            "disableNestedConfig" to settings.disableNestedConfig,
+            "fixKind" to settings.fixKind.toLspValue(),
+            // Deprecated flags kept for backward compat with older servers
             "flags" to mapOf(
                 "disable_nested_config" to settings.disableNestedConfig.toString(),
                 "fix_kind" to settings.fixKind.toLspValue(),


### PR DESCRIPTION
## Summary
- Send `disableNestedConfig` as a root-level boolean and `fixKind` as a root-level string in LSP workspace config, fixing the bug where the deprecated `flags` map format caused nested configs to always be disabled (the server only checks key existence, ignoring the value)
- Recognize `.oxlintrc.jsonc` and `oxlint.config.ts` as config files for the file watcher, icon provider, and schema provider
- Use `isOxlintJsonConfigFile()` in the schema provider so JSON schema isn't incorrectly applied to `oxlint.config.ts`

Fixes https://github.com/oxc-project/oxc-intellij-plugin/issues/404

## Test plan
- [x] Existing tests pass (`./gradlew test`)
- [x] Manual test: project with nested `oxlint.config.ts` in subdirectories picks up subdirectory rules
- [ ] Verify config watcher restarts server on `.oxlintrc.jsonc` and `oxlint.config.ts` changes