### PR TITLE
fix(ci): create changelog PR with GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,23 @@ jobs:
       pull-requests: write
     steps:
 
+      # Mint a GitHub App token. The default GITHUB_TOKEN cannot open pull
+      # requests when "Allow GitHub Actions to create and approve pull requests"
+      # is disabled, so the changelog PR step below is authenticated as the app.
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       # Check out current repository
       - name: Fetch Sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
           ref: ${{ github.event.release.tag_name }}
+          token: ${{ steps.app-token.outputs.token }}
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -80,7 +91,7 @@ jobs:
       - name: Create Pull Request
         if: ${{ steps.properties.outputs.changelog != '' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           VERSION="$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ jobs:
       pull-requests: write
     steps:
 
-      # Mint a GitHub App token. The default GITHUB_TOKEN cannot open pull
-      # requests when "Allow GitHub Actions to create and approve pull requests"
-      # is disabled, so the changelog PR step below is authenticated as the app.
       - name: Generate GitHub App Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token


### PR DESCRIPTION
## Problem

The `Release` workflow's **Create Pull Request** step fails on every release:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

([failing run](https://github.com/oxc-project/oxc-intellij-plugin/actions/runs/26727550661/job/78765326985))

The branch push succeeds — only `gh pr create` is rejected. This is the standard symptom of the **"Allow GitHub Actions to create and approve pull requests"** setting being disabled, which blocks the default `GITHUB_TOKEN` from opening PRs.

## Fix

Mint a GitHub App token with `actions/create-github-app-token` and use it instead:

- Added the token step before checkout.
- Passed the token to `actions/checkout` so the changelog branch push is authenticated as the app — this also lets the PR's `pull_request` CI run (workflows don't trigger for `GITHUB_TOKEN` actors).
- Switched the **Create Pull Request** step from `secrets.GITHUB_TOKEN` to the app token.

## Requirements

- Secrets `APP_ID` (holds the App **Client ID** — it's mapped to `client-id`) and `APP_PRIVATE_KEY` must exist.
- The GitHub App must be installed on the repo with **Contents: write** and **Pull requests: write**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)