### PR TITLE
fix: Update Oxfmt to run after FormatOnSaveAction and after OxlintFixAllOnSaveAction

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,7 +59,7 @@
         <actionOnSave
                 id="OxfmtFixAllOnSaveAction"
                 implementation="com.github.oxc.project.oxcintellijplugin.oxfmt.actions.OxfmtFixAllOnSaveAction"
-                order="first, before FormatOnSaveAction"
+                order="after FormatOnSaveAction, after OxlintFixAllOnSaveAction"
         />
     </extensions>
 


### PR DESCRIPTION
Running after FormatOnSaveAction ensures formatting happens after imports are optimized.
Running after OxlintFixAllOnSaveAction ensures that formatting is only done after Oxlint fixes are completed.

Fixes #534